### PR TITLE
Removed exception for non linear interpolation flags

### DIFF
--- a/cmake/resonanceReconstruction_dependencies.cmake
+++ b/cmake/resonanceReconstruction_dependencies.cmake
@@ -32,7 +32,7 @@ FetchContent_Declare( dimwits
 
 FetchContent_Declare( elementary
     GIT_REPOSITORY  http://github.com/njoy/elementary
-    GIT_TAG         origin/feature/ReactionType
+    GIT_TAG         v0.1.1
     )
 
 

--- a/src/resonanceReconstruction/rmatrix/src/makeLegacyUnresolvedResonanceTable.hpp
+++ b/src/resonanceReconstruction/rmatrix/src/makeLegacyUnresolvedResonanceTable.hpp
@@ -3,13 +3,6 @@ makeLegacyUnresolvedResonanceTable(
     const ENDF::unresolved::EnergyDependent::JValue& endfParameters,
     const std::vector< double >& ) {
 
-  if ( endfParameters.INT() != 2 ) {
-
-    throw std::runtime_error( "Interpolation type "
-                              + std::to_string( endfParameters.INT() ) +
-                              " has not been implemented" );
-  }
-
   // some usefull lambdas
   auto toEnergy = [&] ( double value ) -> Energy {
 


### PR DESCRIPTION
It appears that unresolved resonance parameters are always interpolated using lin-lin interpolation. The interpolation flag in ENDF only applies to the way NJOY interpolates the resulting cross sections.

The exception for non lin-lin interpolation flags can therefore removed and RECONR should use the flag to interpolate on the cross sections coming out of the reconstructor object.