### PR TITLE
Added a function to create the ReactionID in the channel

### DIFF
--- a/src/resonanceReconstruction/rmatrix/Channel.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel.hpp
@@ -22,6 +22,7 @@ class Channel {
 
   /* auxiliary functions */
   #include "resonanceReconstruction/rmatrix/Channel/src/makeChannelID.hpp"
+  #include "resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp"
 
   //! @todo the boundary condition may be dependent on the channel radius (see
   //!       equation d.41 in the ENDF manual)

--- a/src/resonanceReconstruction/rmatrix/Channel/src/ctor.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel/src/ctor.hpp
@@ -62,7 +62,7 @@ Channel( const ParticlePair& incident,
          const ChannelRadii& radii,
          const BoundaryCondition& boundary = 0.0 ) :
   Channel( makeChannelID( pair.pairID().symbol(), numbers ),
-           ReactionID( incident.pairID(), pair.pairID() ),
+           ReactionID( makeReactionID( incident.pairID(), pair.pairID() ) ),
            incident, pair, qValue, numbers, radii, boundary ) {}
 
 /**
@@ -97,5 +97,5 @@ Channel( const ParticlePair& incident,
          const ChannelRadii& radii,
          const BoundaryCondition& boundary = 0.0 ) :
   Channel( makeChannelID( id, numbers ),
-           ReactionID( incident.pairID(), pair.pairID() ),
+           ReactionID( makeReactionID( incident.pairID(), pair.pairID() ) ),
            incident, pair, qValue, numbers, radii, boundary ) {}

--- a/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
@@ -5,7 +5,7 @@ ReactionID makeReactionID( const ParticlePairID& incident,
   if ( incident == pair ) {
 
     return ReactionID( incident.particle(), incident.residual(),
-                       ReactionType( "elastic" ) );
+                       elementary::ReactionType( "elastic" ) );
   }
   return ReactionID( incident, pair );
 }

--- a/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
@@ -1,0 +1,11 @@
+static
+ReactionID makeReactionID( const ParticlePairID& incident,
+                           const ParticlePairID& pair ) {
+
+  if ( incident == pair ) {
+
+    return ReactionID( incident.particle(), incident.residual(),
+                       ReactionType( "elastic" ) );
+  }
+  return ReactionID( incident, pair );
+}


### PR DESCRIPTION
This new function will ensure that the LRF7 work will properly generate an elastic cross section identifier. There shouldn't be any issue today since no LRF7 evaluation exists for metastable states.

Once the lrf3tp7 branch is pulled in (see other pull request), we might have seen the issue there.