### PR TITLE
Fix/emptyspingroup

### DIFF
--- a/src/resonanceReconstruction/rmatrix/Channel.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel.hpp
@@ -22,6 +22,7 @@ class Channel {
 
   /* auxiliary functions */
   #include "resonanceReconstruction/rmatrix/Channel/src/makeChannelID.hpp"
+  #include "resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp"
 
   //! @todo the boundary condition may be dependent on the channel radius (see
   //!       equation d.41 in the ENDF manual)

--- a/src/resonanceReconstruction/rmatrix/Channel/src/ctor.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel/src/ctor.hpp
@@ -62,7 +62,7 @@ Channel( const ParticlePair& incident,
          const ChannelRadii& radii,
          const BoundaryCondition& boundary = 0.0 ) :
   Channel( makeChannelID( pair.pairID().symbol(), numbers ),
-           ReactionID( incident.pairID(), pair.pairID() ),
+           ReactionID( makeReactionID( incident.pairID(), pair.pairID() ) ),
            incident, pair, qValue, numbers, radii, boundary ) {}
 
 /**
@@ -97,5 +97,5 @@ Channel( const ParticlePair& incident,
          const ChannelRadii& radii,
          const BoundaryCondition& boundary = 0.0 ) :
   Channel( makeChannelID( id, numbers ),
-           ReactionID( incident.pairID(), pair.pairID() ),
+           ReactionID( makeReactionID( incident.pairID(), pair.pairID() ) ),
            incident, pair, qValue, numbers, radii, boundary ) {}

--- a/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
@@ -5,7 +5,7 @@ ReactionID makeReactionID( const ParticlePairID& incident,
   if ( incident == pair ) {
 
     return ReactionID( incident.particle(), incident.residual(),
-                       ReactionType( "elastic" ) );
+                       elementary::ReactionType( "elastic" ) );
   }
   return ReactionID( incident, pair );
 }

--- a/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
+++ b/src/resonanceReconstruction/rmatrix/Channel/src/makeReactionID.hpp
@@ -1,0 +1,11 @@
+static
+ReactionID makeReactionID( const ParticlePairID& incident,
+                           const ParticlePairID& pair ) {
+
+  if ( incident == pair ) {
+
+    return ReactionID( incident.particle(), incident.residual(),
+                       ReactionType( "elastic" ) );
+  }
+  return ReactionID( incident, pair );
+}

--- a/src/resonanceReconstruction/rmatrix/src/makeResonanceTable.hpp
+++ b/src/resonanceReconstruction/rmatrix/src/makeResonanceTable.hpp
@@ -67,11 +67,18 @@ makeResonanceTable(
 
     id.erase( id.begin() + eliminated );
   }
-  auto resonances =
-      ranges::view::zip_with( toResonance,
-                              endfParameters.resonanceEnergies()
-                                | ranges::view::transform( toEnergy ),
-                              endfParameters.resonanceParameters() );
+  if ( endfParameters.numberResonances() ) {
 
-  return ResonanceTable( std::move( id ), std::move( resonances ) );
+    auto resonances =
+        ranges::view::zip_with( toResonance,
+                                endfParameters.resonanceEnergies()
+                                  | ranges::view::transform( toEnergy ),
+                                endfParameters.resonanceParameters() );
+
+    return ResonanceTable( std::move( id ), std::move( resonances ) );
+  }
+  else {
+
+    return ResonanceTable( std::move( id ), {} );
+  }
 }


### PR DESCRIPTION
Whenever an empty spin group is encountered, an empty resonance table is created.

fix/mt2 should be merged FIRST.