### PR TITLE
Fixing issue #26

### DIFF
--- a/cmake/resonanceReconstruction_dependencies.cmake
+++ b/cmake/resonanceReconstruction_dependencies.cmake
@@ -32,7 +32,7 @@ FetchContent_Declare( dimwits
 
 FetchContent_Declare( elementary
     GIT_REPOSITORY  http://github.com/njoy/elementary
-    GIT_TAG         v0.1.1
+    GIT_TAG         feature/resolve
     )
 
 

--- a/src/resonanceReconstruction/rmatrix/src/fromENDF.hpp
+++ b/src/resonanceReconstruction/rmatrix/src/fromENDF.hpp
@@ -43,6 +43,7 @@ fromENDF( const ENDF::ResonanceRange& endfResonanceRange,
                            upper * electronVolt,
                            makeCompoundSystem( endfRMatrix,
                                                neutronMass, elementaryCharge,
+                                               incident, target,
                                                ReichMoore(), ShiftFactor() ) );
               }
               else {
@@ -52,6 +53,7 @@ fromENDF( const ENDF::ResonanceRange& endfResonanceRange,
                            upper * electronVolt,
                            makeCompoundSystem( endfRMatrix,
                                                neutronMass, elementaryCharge,
+                                               incident, target,
                                                ReichMoore(), Constant() ) );
               }
             }

--- a/src/resonanceReconstruction/rmatrix/src/makeCompoundSystem.hpp
+++ b/src/resonanceReconstruction/rmatrix/src/makeCompoundSystem.hpp
@@ -4,12 +4,15 @@ makeCompoundSystem(
     const ENDF::resolved::RMatrixLimited& endfRMatrix,
     const AtomicMass& neutronMass,
     const ElectricalCharge& elementaryCharge,
+    const ParticleID& incident,
+    const ParticleID& target,
     Formalism formalism,
     BoundaryOption boundaryOption ) {
 
   auto endfPairs = endfRMatrix.particlePairs();
-  auto pairs = makeParticlePairs( endfPairs, neutronMass, elementaryCharge );
-  auto incident = pairs[ rmatrix::incident( endfPairs ) ];
+  auto pairs = makeParticlePairs( endfPairs, neutronMass, elementaryCharge,
+                                  incident, target );
+  auto in = pairs[ rmatrix::incident( endfPairs ) ];
   bool reducedWidthsFlag = endfRMatrix.reducedWidths() == 0 ? false : true;
 
   std::vector< SpinGroup< Formalism, BoundaryOption > > spingroups =
@@ -17,7 +20,7 @@ makeCompoundSystem(
         | ranges::view::transform(
               [&] ( const auto& spingroup ) {
 
-                return makeSpinGroup( incident, pairs,
+                return makeSpinGroup( in, pairs,
                                       endfRMatrix.particlePairs(),
                                       spingroup, reducedWidthsFlag,
                                       formalism, boundaryOption );

--- a/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
@@ -376,7 +376,7 @@ SCENARIO( "fromENDF" ) {
     njoy::ENDFtk::section::Type< 2, 151 > endf( head, begin, end, lineNumber, 2025 );
     ResonanceRange endfResonanceRange = endf.isotopes().front().resonanceRanges().front();
 
-    auto resonances = fromENDF( endfResonanceRange, neutronMass, elementaryCharge, ParticleID( "n" ), ParticleID( "Fe54" ) );
+    auto resonances = fromENDF( endfResonanceRange, neutronMass, elementaryCharge, ParticleID( "n" ), ParticleID( "Ca40" ) );
 
     THEN( "the appropriate CompoundSystem is returned" ) {
 
@@ -750,7 +750,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( 19.0 * 1.602e-19 == Approx( pair21.residual().charge().value ) );
       CHECK( 4.0 == Approx( pair21.residual().spin() ) );
       CHECK( -1 == pair21.residual().parity() );
-      CHECK( "p,K40_e1" == pair21.pairID().symbol() );
+      CHECK( "p,K40" == pair21.pairID().symbol() );
 
       // quantum numbers
       const auto numbers21 = channel21.quantumNumbers();
@@ -1130,7 +1130,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( 19.0 * 1.602e-19 == Approx( pair41.residual().charge().value ) );
       CHECK( 4.0 == Approx( pair41.residual().spin() ) );
       CHECK( -1 == pair41.residual().parity() );
-      CHECK( "p,K40_e1" == pair41.pairID().symbol() );
+      CHECK( "p,K40" == pair41.pairID().symbol() );
 
       // quantum numbers
       const auto numbers41 = channel41.quantumNumbers();


### PR DESCRIPTION
Particle identifiers are now resolved from the incident and target instead of derived from z and a since z can sometimes be zero.