### PR TITLE
Added ability to multiply BreitWigner::CrossSection with a scalar.

### DIFF
--- a/src/resonanceReconstruction/breitWigner/CrossSection.hpp
+++ b/src/resonanceReconstruction/breitWigner/CrossSection.hpp
@@ -26,4 +26,11 @@ struct CrossSection {
              this->capture - other.capture,
              this->fission - other.fission };
   }
+
+  template< class ScalarValue >
+  CrossSection operator*( const ScalarValue& value ) const {
+    return { value * this->elastic,
+             value * this->capture,
+             value * this->fission };
+  }
 };


### PR DESCRIPTION
Probably should add a test case, so this isn't really ready to go.  But branch exists if you need it now!