### PR TITLE
feature/intunr

### DIFF
--- a/src/resonanceReconstruction/rmatrix/Reconstructor.hpp
+++ b/src/resonanceReconstruction/rmatrix/Reconstructor.hpp
@@ -112,6 +112,21 @@ public:
     }
     return result;
   }
+
+  /**
+   *  @brief Return the interpolation scheme
+   *
+   *  @param[in] energy   the energy for which the radius must be given
+   */
+  int interpolation() const {
+
+    return std::visit(
+             njoy::utility::overload{
+                 [&] ( const legacy::unresolved::CompoundSystem& system )
+                     { return system.interpolation(); },
+                 [&] ( const auto& ) { return 2; } },
+             this->system_ );
+  }
 };
 
 } // rmatrix namespace

--- a/src/resonanceReconstruction/rmatrix/Reconstructor.hpp
+++ b/src/resonanceReconstruction/rmatrix/Reconstructor.hpp
@@ -118,13 +118,16 @@ public:
    *
    *  @param[in] energy   the energy for which the radius must be given
    */
-  int interpolation() const {
+  std::optional< int > interpolation() const {
 
     return std::visit(
              njoy::utility::overload{
                  [&] ( const legacy::unresolved::CompoundSystem& system )
-                     { return system.interpolation(); },
-                 [&] ( const auto& ) { return 2; } },
+                     -> std::optional< int >
+                     { return std::make_optional( system.interpolation() ); },
+                 [&] ( const auto& )
+                     -> std::optional< int >
+                     { return std::nullopt; } },
              this->system_ );
   }
 };

--- a/src/resonanceReconstruction/rmatrix/fromENDF.hpp
+++ b/src/resonanceReconstruction/rmatrix/fromENDF.hpp
@@ -4,6 +4,8 @@
 // system includes
 
 // other includes
+#include "range/v3/algorithm/count.hpp"
+#include "resonanceReconstruction/endf.hpp"
 #include "resonanceReconstruction/endf.hpp"
 #include "resonanceReconstruction/Quantity.hpp"
 #include "resonanceReconstruction/rmatrix/Formalism.hpp"
@@ -200,7 +202,7 @@ fromENDF( const endf::ResonanceRange& endfResonanceRange,
                      lower * electronVolt,
                      upper * electronVolt,
                      makeLegacyUnresolvedCompoundSystem(
-                         endfEnergyDependent, neutronMass, 
+                         endfEnergyDependent, neutronMass,
                          incident, target, nro, naps, lower, upper ) );
         }
         default : {

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem.hpp
@@ -29,14 +29,21 @@ namespace unresolved {
  */
 class CompoundSystem : protected CompoundSystemBase< unresolved::SpinGroup > {
 
+  int interpolation_;
+
 public:
 
   /* constructor */
-  using CompoundSystemBase::CompoundSystemBase;
+  #include "resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/src/ctor.hpp"
 
   /* methods */
   using CompoundSystemBase::spinGroups;
   using CompoundSystemBase::evaluate;
+
+  /**
+   *  @brief Return the interpolation scheme to be applied
+   */
+  int interpolation() const { return this->interpolation_; }
 
   #include "resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/src/grid.hpp"
 };

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/src/ctor.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/src/ctor.hpp
@@ -1,0 +1,10 @@
+/**
+ *  @brief Constructor
+ *
+ *  @param[in] groups          all l,J groups that apply to the compound system
+ *  @param[in] interpolation   interpolation scheme to be used for cross
+ *                             sections
+ */
+CompoundSystem( std::vector< unresolved::SpinGroup >&& groups,
+                int interpolation ) :
+  CompoundSystemBase( std::move( groups ) ), interpolation_( interpolation ) {}

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/test/CompoundSystem.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/test/CompoundSystem.test.hpp
@@ -43,9 +43,10 @@ SCENARIO( "CompoundSystem" ) {
 
       Energy energy = 1e-5 * electronVolts;
 
-      CompoundSystem system( { group1, group2 } );
+      CompoundSystem system( { group1, group2 }, 5 );
 
       CHECK( 2 == system.spinGroups().size() );
+      CHECK( 5 == system.interpolation() );
 
       // group 1 - l,J = 0,0
       auto group = system.spinGroups()[0];
@@ -251,13 +252,13 @@ SCENARIO( "CompoundSystem" ) {
     THEN( "an exception is thrown at construction when there are no spin "
           "groups" ) {
 
-      CHECK_THROWS( CompoundSystem( std::vector< SpinGroup >{} ) );
+      CHECK_THROWS( CompoundSystem( std::vector< SpinGroup >{}, 2 ) );
     } // THEN
 
     THEN( "an exception is thrown at construction when the spin groups "
           "are not unique" ) {
 
-      CHECK_THROWS( CompoundSystem( { group, group } ) );
+      CHECK_THROWS( CompoundSystem( { group, group }, 2 ) );
     } // THEN
   } // GIVEN
 } // SCENARIO

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/test/evaluate.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/test/evaluate.test.hpp
@@ -125,7 +125,7 @@ SCENARIO( "evaluate" ) {
     // the compound system
     CompoundSystem system( { group00, group01, group10, group11, group12,
                              group13, group20, group21, group22, group23,
-                             group24, group25 } );
+                             group24, group25 }, 5 );
 
     ReactionID elas( "n,Na22->n,Na22" );
     ReactionID capt( "n,Na22->capture" );
@@ -604,7 +604,7 @@ SCENARIO( "evaluate" ) {
     SpinGroup group12( std::move( elastic12 ), std::move( table12 ) );
 
     // the compound system
-    CompoundSystem system( { group00, group01, group10, group11, group12 } );
+    CompoundSystem system( { group00, group01, group10, group11, group12 }, 2 );
 
     ReactionID elas( "n,Pu239->n,Pu239" );
     ReactionID capt( "n,Pu239->capture" );

--- a/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
@@ -23,7 +23,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.036e+6 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -451,7 +451,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.5e+6 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -1343,7 +1343,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.2e+6 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
@@ -23,6 +23,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.036e+6 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -450,6 +451,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.5e+6 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -1341,6 +1343,7 @@ SCENARIO( "fromENDF" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.2e+6 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedMLBW.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedMLBW.test.hpp
@@ -27,6 +27,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 7.5 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -205,6 +206,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 6500. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -717,6 +719,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 3.2 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -887,6 +890,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 2008. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -1067,6 +1071,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 4845. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedMLBW.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedMLBW.test.hpp
@@ -27,7 +27,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 7.5 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -206,7 +206,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 6500. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -719,7 +719,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 3.2 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -890,7 +890,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 2008. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -1071,7 +1071,7 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 4845. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedReichMoore.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedReichMoore.test.hpp
@@ -22,6 +22,7 @@ SCENARIO( "fromENDF - LRF3" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 2500. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -1187,6 +1188,7 @@ SCENARIO( "fromENDF - LRF3" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.3e+6 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedReichMoore.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedReichMoore.test.hpp
@@ -22,7 +22,7 @@ SCENARIO( "fromENDF - LRF3" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 2500. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -1188,7 +1188,7 @@ SCENARIO( "fromENDF - LRF3" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.3e+6 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedSLBW.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedSLBW.test.hpp
@@ -24,6 +24,7 @@ SCENARIO( "fromENDF - LRF1" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 7.5 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< SingleLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -199,6 +200,7 @@ SCENARIO( "fromENDF - LRF1" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 366.5 == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< SingleLevelBreitWigner > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedSLBW.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedSLBW.test.hpp
@@ -24,7 +24,7 @@ SCENARIO( "fromENDF - LRF1" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 7.5 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< SingleLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -200,7 +200,7 @@ SCENARIO( "fromENDF - LRF1" ) {
       CHECK( false == resonances.isUnresolved() );
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 366.5 == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( false == bool( resonances.interpolation() ) );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< SingleLevelBreitWigner > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFUnresolved.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFUnresolved.test.hpp
@@ -25,12 +25,16 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( true == resonances.isUnresolved() );
       CHECK( 15000. == Approx( resonances.lowerEnergy().value ) );
       CHECK( 100000. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
       // content verification
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+      // interpolation
+      CHECK( 2 == compoundsystem.interpolation() );
 
       // spin groups
       auto spingroups = compoundsystem.spinGroups();
@@ -514,12 +518,16 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( true == resonances.isUnresolved() );
       CHECK( 2500. == Approx( resonances.lowerEnergy().value ) );
       CHECK( 30000. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
       // content verification
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+      // interpolation
+      CHECK( 2 == compoundsystem.interpolation() );
 
       // spin groups
       auto spingroups = compoundsystem.spinGroups();
@@ -1210,11 +1218,20 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
 
     THEN( "the appropriate CompoundSystem is returned" ) {
 
+      CHECK( false == resonances.isResolved() );
+      CHECK( true == resonances.isUnresolved() );
+      CHECK( 1750. == Approx( resonances.lowerEnergy().value ) );
+      CHECK( 10000. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 5 == resonances.interpolation() );
+
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
       // content verification
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+      // interpolation
+      CHECK( 5 == compoundsystem.interpolation() );
 
       // spin groups
       auto spingroups = compoundsystem.spinGroups();
@@ -1505,11 +1522,20 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
 
     THEN( "the appropriate CompoundSystem is returned" ) {
 
+      CHECK( false == resonances.isResolved() );
+      CHECK( true == resonances.isUnresolved() );
+      CHECK( 2000. == Approx( resonances.lowerEnergy().value ) );
+      CHECK( 100000. == Approx( resonances.upperEnergy().value ) );
+      CHECK( 2 == resonances.interpolation() );
+
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
       // content verification
       // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+      // interpolation
+      CHECK( 2 == compoundsystem.interpolation() );
 
       // spin groups
       auto spingroups = compoundsystem.spinGroups();

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFUnresolved.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFUnresolved.test.hpp
@@ -25,7 +25,8 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( true == resonances.isUnresolved() );
       CHECK( 15000. == Approx( resonances.lowerEnergy().value ) );
       CHECK( 100000. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( true == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.interpolation().value() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
@@ -518,7 +519,8 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( true == resonances.isUnresolved() );
       CHECK( 2500. == Approx( resonances.lowerEnergy().value ) );
       CHECK( 30000. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( true == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.interpolation().value() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
@@ -1222,7 +1224,8 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( true == resonances.isUnresolved() );
       CHECK( 1750. == Approx( resonances.lowerEnergy().value ) );
       CHECK( 10000. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 5 == resonances.interpolation() );
+      CHECK( true == bool( resonances.interpolation() ) );
+      CHECK( 5 == resonances.interpolation().value() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
@@ -1526,7 +1529,8 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( true == resonances.isUnresolved() );
       CHECK( 2000. == Approx( resonances.lowerEnergy().value ) );
       CHECK( 100000. == Approx( resonances.upperEnergy().value ) );
-      CHECK( 2 == resonances.interpolation() );
+      CHECK( true == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.interpolation().value() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 


### PR DESCRIPTION
Added interpolation scheme to the unresolved compound system and added a convenience function on the Reconstructor

Outstanding question: the interpolation scheme is useless for the resolved, so I decided to return 2 in those cases. However, to better reflect the "uselessness", we might consider using an optional. What do you think?

In addition: an enumerator for interpolation schemes might be useful as well - but less of an issue.