### PR TITLE
Added reactionIDs() functions

### DIFF
--- a/src/resonanceReconstruction/rmatrix/CompoundSystem.hpp
+++ b/src/resonanceReconstruction/rmatrix/CompoundSystem.hpp
@@ -35,8 +35,10 @@ class CompoundSystem {
 
   /* fields */
   std::vector< SpinGroup< Formalism, BoundaryOption > > groups_;
+  std::vector< ReactionID > reactions_;
 
   /* auxiliary functions */
+  #include "resonanceReconstruction/rmatrix/CompoundSystem/src/makeReactionIDs.hpp"
   #include "resonanceReconstruction/rmatrix/CompoundSystem/src/makeSpinGroups.hpp"
   #include "resonanceReconstruction/rmatrix/CompoundSystem/src/verifySpinGroups.hpp"
 
@@ -46,6 +48,11 @@ public:
   #include "resonanceReconstruction/rmatrix/CompoundSystem/src/ctor.hpp"
 
   auto spinGroups() const { return ranges::view::all( this->groups_ ); }
+
+  /**
+   *  @brief Return the reactions defined in the compound system
+   */
+  auto reactionIDs() const { return ranges::view::all( this->reactions_ ); }
 
   //#include "resonanceReconstruction/rmatrix/CompoundSystem/src/switchIncidentPair.hpp"
   #include "resonanceReconstruction/rmatrix/CompoundSystem/src/evaluate.hpp"

--- a/src/resonanceReconstruction/rmatrix/CompoundSystem/src/ctor.hpp
+++ b/src/resonanceReconstruction/rmatrix/CompoundSystem/src/ctor.hpp
@@ -1,13 +1,24 @@
+private:
+
+/**
+ *  @brief Private constructor
+ */
+CompoundSystem( std::vector< ReactionID >&& reactions,
+                std::vector< SpinGroup< Formalism, BoundaryOption > >&& groups ) :
+  reactions_( std::move( reactions ) ), groups_( std::move( groups ) ) {
+
+  verifySpinGroups( this->groups_ );
+}
+
+public:
+
 /**
  *  @brief Constructor
  *
  *  @param[in] groups   the different spin groups in the compound system
  */
 CompoundSystem( std::vector< SpinGroup< Formalism, BoundaryOption > >&& groups ) :
-  groups_( std::move( groups ) ) {
-
-  verifySpinGroups( this->groups_ );
-}
+  CompoundSystem( makeReactionIDs( groups ), std::move( groups ) ) {}
 
 /**
  *  @brief Constructor

--- a/src/resonanceReconstruction/rmatrix/CompoundSystem/src/makeReactionIDs.hpp
+++ b/src/resonanceReconstruction/rmatrix/CompoundSystem/src/makeReactionIDs.hpp
@@ -1,0 +1,17 @@
+static
+std::vector< ReactionID >
+makeReactionIDs( const std::vector< SpinGroup< Formalism, BoundaryOption > >& groups ) {
+
+  std::vector< ReactionID > reactions;
+
+  reactions = groups | ranges::view::transform(
+                           [] ( const auto& group )
+                              { return group.reactionIDs(); } )
+                     | ranges::view::join;
+
+  std::sort( reactions.begin(), reactions.end() );
+  reactions.erase( std::unique( reactions.begin(), reactions.end() ),
+                   reactions.end() );
+
+  return reactions;
+}

--- a/src/resonanceReconstruction/rmatrix/CompoundSystem/src/makeSpinGroups.hpp
+++ b/src/resonanceReconstruction/rmatrix/CompoundSystem/src/makeSpinGroups.hpp
@@ -8,7 +8,8 @@ makeSpinGroups( std::vector< ParticleChannelData >&& channels ) {
   auto getJpi = [] ( const auto& channel ) {
 
     return std::make_pair( channel.quantumNumbers().totalAngularMomentum(),
-                           channel.quantumNumbers().parity() ); };
+                           channel.quantumNumbers().parity() );
+  };
 
   // get the different Jpi values in the channels
   std::vector< std::pair< TotalAngularMomentum, Parity > > spins =

--- a/src/resonanceReconstruction/rmatrix/CompoundSystem/test/CompoundSystem.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/CompoundSystem/test/CompoundSystem.test.hpp
@@ -236,6 +236,12 @@ void checkCompoundSystem( const CompoundSystem< ReichMoore, ShiftFactor >& syste
   // number of spin groups
   CHECK( 5 == system.spinGroups().size() );
 
+  // reaction identifiers
+  auto reactions = system.reactionIDs();
+  CHECK( 2 == reactions.size() );
+  CHECK( "n,Fe54->capture" == reactions[0].symbol() );
+  CHECK( "n,Fe54->n,Fe54" == reactions[1].symbol() );
+
   // group 1 - Jpi = 0.5-
   auto group = system.spinGroups()[0];
   CHECK( 1 == group.incidentChannels().size() );

--- a/src/resonanceReconstruction/rmatrix/Reconstructor.hpp
+++ b/src/resonanceReconstruction/rmatrix/Reconstructor.hpp
@@ -81,6 +81,16 @@ public:
   const Energy& upperEnergy() const { return this->upper_; }
 
   /**
+   *  @brief Return the reaction identifiers for this reconstructor
+   */
+  auto reactionIDs() {
+
+    return std::visit( [] ( const auto& system )
+                          { return system.reactionIDs(); },
+                       this->compoundSystem() );
+  }
+
+  /**
    *  @brief Return the minimal energy grid derived from the resonance
    *         parameters
    */
@@ -99,6 +109,9 @@ public:
 
   /**
    *  @brief Reconstruct the cross sections at the given energy
+   *
+   *  @param[in] energy   the energy for which cross sections are to be
+   *                      calculated
    */
   Map< ReactionID, CrossSection > operator()( const Energy& energy ) {
 
@@ -115,8 +128,6 @@ public:
 
   /**
    *  @brief Return the interpolation scheme
-   *
-   *  @param[in] energy   the energy for which the radius must be given
    */
   std::optional< int > interpolation() const {
 

--- a/src/resonanceReconstruction/rmatrix/Resonance/test/Resonance.test.cpp
+++ b/src/resonanceReconstruction/rmatrix/Resonance/test/Resonance.test.cpp
@@ -9,4 +9,3 @@ using namespace njoy::resonanceReconstruction;
 using Resonance = rmatrix::Resonance;
 
 #include "../src/resonanceReconstruction/rmatrix/Resonance/test/Resonance.test.hpp"
-#include "../src/resonanceReconstruction/rmatrix/Resonance/test/rmatrix.test.hpp"

--- a/src/resonanceReconstruction/rmatrix/legacy/CompoundSystemBase.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/CompoundSystemBase.hpp
@@ -9,6 +9,7 @@
 #include "range/v3/algorithm/count_if.hpp"
 #include "range/v3/view/all.hpp"
 #include "range/v3/view/transform.hpp"
+#include "range/v3/view/join.hpp"
 #include "resonanceReconstruction/Quantity.hpp"
 #include "resonanceReconstruction/rmatrix/Map.hpp"
 #include "resonanceReconstruction/rmatrix/ReactionID.hpp"
@@ -31,9 +32,11 @@ class CompoundSystemBase {
 
   /* fields */
   std::vector< SpinGroupType > groups_;
+  std::vector< ReactionID > reactions_;
   unsigned int lmax_;
 
   /* auxiliary functions */
+  #include "resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/makeReactionIDs.hpp"
   #include "resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/getLMax.hpp"
   #include "resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/verifySpinGroups.hpp"
 
@@ -46,6 +49,11 @@ public:
    *  @brief Return the l,J data
    */
   auto spinGroups() const { return ranges::view::all( this->groups_ ); }
+
+  /**
+   *  @brief Return the reactions defined in the compound system
+   */
+  auto reactionIDs() const { return ranges::view::all( this->reactions_ ); }
 
   #include "resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/evaluate.hpp"
 };

--- a/src/resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/ctor.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/ctor.hpp
@@ -4,8 +4,10 @@ private:
  *  @brief Private constructor
  */
 CompoundSystemBase( std::vector< SpinGroupType >&& groups,
+                    std::vector< ReactionID >&& reactions,
                     unsigned int lmax ) :
-  groups_( std::move( groups ) ), lmax_( lmax ) {
+  groups_( std::move( groups ) ), reactions_( std::move( reactions ) ),
+  lmax_( lmax ) {
 
     verifySpinGroups( this->groups_ );
   }
@@ -19,4 +21,6 @@ public:
  *  @param[in] groups   all l,J groups that apply to the compound system
  */
 CompoundSystemBase( std::vector< SpinGroupType >&& groups ) :
-  CompoundSystemBase( std::move( groups ), getLMax( groups ) ) {}
+  CompoundSystemBase( std::move( groups ),
+                      makeReactionIDs( groups ),
+                      getLMax( groups ) ) {}

--- a/src/resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/makeReactionIDs.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/CompoundSystemBase/src/makeReactionIDs.hpp
@@ -1,0 +1,17 @@
+static
+std::vector< ReactionID >
+makeReactionIDs( const std::vector< SpinGroupType >& groups ) {
+
+  std::vector< ReactionID > reactions;
+
+  reactions = groups | ranges::view::transform(
+                           [] ( const auto& group )
+                              { return group.reactionIDs(); } )
+                     | ranges::view::join;
+
+  std::sort( reactions.begin(), reactions.end() );
+  reactions.erase( std::unique( reactions.begin(), reactions.end() ),
+                   reactions.end() );
+
+  return reactions;
+}

--- a/src/resonanceReconstruction/rmatrix/legacy/SpinGroupBase/src/ctor.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/SpinGroupBase/src/ctor.hpp
@@ -1,0 +1,21 @@
+private:
+
+/**
+ *  @brief Private constructor
+ */
+SpinGroupBase( std::vector< ReactionID >&& reactions,
+               Channel< Neutron >&& incident, ResonanceTableType&& table ) :
+  incident_( std::move( incident ) ), table_( std::move( table ) ),
+  reactions_( std::move( reactions ) ) {}
+
+public:
+
+/**
+ *  @brief Constructor
+ *
+ *  @param[in] incident   the incident channel data for this l,J pair
+ *  @param[in] table      the table of resonance parameters for this l,J pair
+ */
+SpinGroupBase( Channel< Neutron >&& incident, ResonanceTableType&& table ) :
+  SpinGroupBase( makeReactionIdentifiers( incident, table ),
+                 std::move( incident ), std::move( table ) ) {}

--- a/src/resonanceReconstruction/rmatrix/legacy/SpinGroupBase/src/makeReactionIdentifiers.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/SpinGroupBase/src/makeReactionIdentifiers.hpp
@@ -1,0 +1,24 @@
+static
+std::vector< ReactionID >
+makeReactionIdentifiers( const Channel< Neutron >& channel,
+                         const ResonanceTableType& table ) {
+
+  std::vector< ReactionID > reactions;
+
+  // add elastic and capture
+  auto incident = channel.particlePair().particle().particleID();
+  auto target = channel.particlePair().residual().particleID();
+  reactions.push_back( ReactionID{ incident, target, ReactionType( "elastic" ) } );
+  reactions.push_back( ReactionID{ incident, target, ReactionType( "capture" ) } );
+
+  // add fission if it exists
+  if ( ranges::count_if(
+           table.resonances(),
+           [&] ( const auto& resonance )
+               { return resonance.hasFission(); } ) > 1 ) {
+
+    reactions.push_back( ReactionID{ incident, target, ReactionType( "fission" ) } );
+  }
+
+  return reactions;
+}

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/CompoundSystem.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/CompoundSystem.hpp
@@ -38,6 +38,7 @@ public:
   /* methods */
   using CompoundSystemBase< SpinGroup< Formalism > >::spinGroups;
   using CompoundSystemBase< SpinGroup< Formalism > >::evaluate;
+  using CompoundSystemBase< SpinGroup< Formalism > >::reactionIDs;
 
   #include "resonanceReconstruction/rmatrix/legacy/resolved/CompoundSystem/src/grid.hpp"
 };

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/CompoundSystem/test/CompoundSystem.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/CompoundSystem/test/CompoundSystem.test.hpp
@@ -45,6 +45,13 @@ SCENARIO( "CompoundSystem" ) {
 
       CHECK( 1 == system.spinGroups().size() );
 
+      // check the reaction identifiers
+      auto reactions = system.reactionIDs();
+
+      CHECK( 2 == reactions.size() );
+      CHECK( "n,Rh105->capture" == reactions[0].symbol() );
+      CHECK( "n,Rh105->n,Rh105" == reactions[1].symbol() );
+
       // group 1 - l,J = 0,1
       auto group = system.spinGroups()[0];
 

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/Resonance.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/Resonance.hpp
@@ -70,6 +70,11 @@ public:
   const Width& fission() const { return this->fission_; }
 
   /**
+   *  @brief Return whether or not the resonance has fission or not
+   */
+  bool hasFission() const { return this->fission_.value != 0.0; }
+
+  /**
    *  @brief Return the competitive width (in eV)
    */
   const Width& competition() const { return this->competition_; }

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/MultiLevelBreitWigner.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/MultiLevelBreitWigner.hpp
@@ -20,6 +20,8 @@ public:
   using SpinGroup< SingleLevelBreitWigner >::resonanceTable;
   using SpinGroup< SingleLevelBreitWigner >::QX;
   using SpinGroup< SingleLevelBreitWigner >::grid;
+  using SpinGroup< SingleLevelBreitWigner >::reactionIDs;
+  using SpinGroup< SingleLevelBreitWigner >::hasFission;
 
   #include "resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/MultiLevelBreitWigner/src/evaluate.hpp"
 };

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/MultiLevelBreitWigner/test/MultiLevelBreitWigner.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/MultiLevelBreitWigner/test/MultiLevelBreitWigner.test.hpp
@@ -108,6 +108,15 @@ SCENARIO( "SpinGroup" ) {
       CHECK( 0 == Approx( resonance.fission().value ) );
       CHECK( 0 == Approx( resonance.competition().value ) );
 
+      // check the reaction identifiers
+      auto reactions = group.reactionIDs();
+
+      CHECK( 2 == reactions.size() );
+      CHECK( "n,Rh105->n,Rh105" == reactions[0].symbol() );
+      CHECK( "n,Rh105->capture" == reactions[1].symbol() );
+
+      CHECK( false == group.hasFission() );
+
       // check the minimal energy grid
       auto grid = group.grid();
 

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/SingleLevelBreitWigner.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/SingleLevelBreitWigner.hpp
@@ -45,6 +45,8 @@ public:
   using SpinGroupBase::orbitalAngularMomentum;
   using SpinGroupBase::totalAngularMomentum;
   using SpinGroupBase::resonanceTable;
+  using SpinGroupBase::reactionIDs;
+  using SpinGroupBase::hasFission;
 
   /**
    *  @brief Return competitive Q value

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/SingleLevelBreitWigner/src/evaluate.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/SingleLevelBreitWigner/src/evaluate.hpp
@@ -46,7 +46,7 @@ void evaluate( const Energy& energy,
   // calculate the resulting cross sections
   result[ this->elasticID() ] += factor * components.elastic;
   result[ this->captureID() ] += factor * components.capture;
-  if ( components.hasFission() ) {
+  if ( this->hasFission() ) {
 
     result[ this->fissionID() ] += factor * components.fission;
   }

--- a/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/SingleLevelBreitWigner/test/SingleLevelBreitWigner.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/resolved/SpinGroup/SingleLevelBreitWigner/test/SingleLevelBreitWigner.test.hpp
@@ -108,6 +108,15 @@ SCENARIO( "SpinGroup" ) {
       CHECK( 0 == Approx( resonance.fission().value ) );
       CHECK( 0 == Approx( resonance.competition().value ) );
 
+      // check the reaction identifiers
+      auto reactions = group.reactionIDs();
+
+      CHECK( 2 == reactions.size() );
+      CHECK( "n,Rh105->n,Rh105" == reactions[0].symbol() );
+      CHECK( "n,Rh105->capture" == reactions[1].symbol() );
+
+      CHECK( false == group.hasFission() );
+
       // check the minimal energy grid
       auto grid = group.grid();
 

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem.hpp
@@ -39,6 +39,7 @@ public:
   /* methods */
   using CompoundSystemBase::spinGroups;
   using CompoundSystemBase::evaluate;
+  using CompoundSystemBase::reactionIDs;
 
   /**
    *  @brief Return the interpolation scheme to be applied

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/test/CompoundSystem.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/CompoundSystem/test/CompoundSystem.test.hpp
@@ -48,6 +48,14 @@ SCENARIO( "CompoundSystem" ) {
       CHECK( 2 == system.spinGroups().size() );
       CHECK( 5 == system.interpolation() );
 
+      // check the reaction identifiers
+      auto reactions = system.reactionIDs();
+
+      CHECK( 3 == reactions.size() );
+      CHECK( "n,Pu239->capture" == reactions[0].symbol() );
+      CHECK( "n,Pu239->fission" == reactions[1].symbol() );
+      CHECK( "n,Pu239->n,Pu239" == reactions[2].symbol() );
+
       // group 1 - l,J = 0,0
       auto group = system.spinGroups()[0];
 

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/Resonance.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/Resonance.hpp
@@ -63,6 +63,11 @@ public:
   const Width& fission() const { return this->fission_; }
 
   /**
+   *  @brief Return whether or not the resonance has fission or not
+   */
+  bool hasFission() const { return this->fission_.value != 0.0; }
+
+  /**
    *  @brief Return the competitive width (given in eV)
    */
   const Width& competition() const { return this->competition_; }

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup.hpp
@@ -38,6 +38,8 @@ public:
   using SpinGroupBase::orbitalAngularMomentum;
   using SpinGroupBase::totalAngularMomentum;
   using SpinGroupBase::resonanceTable;
+  using SpinGroupBase::reactionIDs;
+  using SpinGroupBase::hasFission;
 
   #include "resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup/src/evaluate.hpp"
 };

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup/src/evaluate.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup/src/evaluate.hpp
@@ -43,7 +43,7 @@ void evaluate( const Energy& energy,
   result[ this->captureID() ] +=
     factor * spinFactor / spacing *
     ( widths.elastic * widths.capture * integrals.capture );
-  if ( widths.hasFission() ) {
+  if ( this->hasFission() ) {
 
     result[ this->fissionID() ] +=
       factor * spinFactor / spacing *

--- a/src/resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup/test/SpinGroup.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/legacy/unresolved/SpinGroup/test/SpinGroup.test.hpp
@@ -103,6 +103,16 @@ SCENARIO( "SpinGroup" ) {
       CHECK( 4.070000e-2 == Approx( resonance.capture().value ) );
       CHECK( 2.693000e+0 == Approx( resonance.fission().value ) );
       CHECK( 0. == Approx( resonance.competition().value ) );
+
+      // check the reaction identifiers
+      auto reactions = group.reactionIDs();
+
+      CHECK( 3 == reactions.size() );
+      CHECK( "n,Pu239->n,Pu239" == reactions[0].symbol() );
+      CHECK( "n,Pu239->capture" == reactions[1].symbol() );
+      CHECK( "n,Pu239->fission" == reactions[2].symbol() );
+
+      CHECK( true == group.hasFission() );
     } // THEN
   } // GIVEN
 } // SCENARIO

--- a/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDF.test.hpp
@@ -24,6 +24,9 @@ SCENARIO( "fromENDF" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.036e+6 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Fe54->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Fe54->n,Fe54" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -452,6 +455,11 @@ SCENARIO( "fromENDF" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.5e+6 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 4 == resonances.reactionIDs().size() );
+      CHECK( "n,Ca40->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Ca40->he4,Ar37" == resonances.reactionIDs()[1].symbol() );
+      CHECK( "n,Ca40->n,Ca40" == resonances.reactionIDs()[2].symbol() );
+      CHECK( "n,Ca40->p,K40" == resonances.reactionIDs()[3].symbol() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -1344,6 +1352,10 @@ SCENARIO( "fromENDF" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.2e+6 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 3 == resonances.reactionIDs().size() );
+      CHECK( "n,Cl35->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Cl35->n,Cl35" == resonances.reactionIDs()[1].symbol() );
+      CHECK( "n,Cl35->p,S35" == resonances.reactionIDs()[2].symbol() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedMLBW.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedMLBW.test.hpp
@@ -28,6 +28,9 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 7.5 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Rh105->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Rh105->n,Rh105" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -207,6 +210,9 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 6500. == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Ag107->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Ag107->n,Ag107" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -720,6 +726,9 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 3.2 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Tm168->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Tm168->n,Tm168" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -891,6 +900,9 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 2008. == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Dy160->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Dy160->n,Dy160" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -1072,6 +1084,9 @@ SCENARIO( "fromENDF - LRF2" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 4845. == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Dy162->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Dy162->n,Dy162" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< MultiLevelBreitWigner > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedReichMoore.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedReichMoore.test.hpp
@@ -23,6 +23,10 @@ SCENARIO( "fromENDF - LRF3" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 2500. == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 3 == resonances.reactionIDs().size() );
+      CHECK( "n,Pu239->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Pu239->fission" == resonances.reactionIDs()[1].symbol() );
+      CHECK( "n,Pu239->n,Pu239" == resonances.reactionIDs()[2].symbol() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 
@@ -1189,6 +1193,9 @@ SCENARIO( "fromENDF - LRF3" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 1.3e+6 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Si29->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Si29->n,Si29" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< CompoundSystem< ReichMoore, ShiftFactor > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedSLBW.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFResolvedSLBW.test.hpp
@@ -25,6 +25,9 @@ SCENARIO( "fromENDF - LRF1" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 7.5 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Rh105->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Rh105->n,Rh105" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< SingleLevelBreitWigner > >( resonances.compoundSystem() );
 
@@ -201,6 +204,10 @@ SCENARIO( "fromENDF - LRF1" ) {
       CHECK( 1e-5 == Approx( resonances.lowerEnergy().value ) );
       CHECK( 366.5 == Approx( resonances.upperEnergy().value ) );
       CHECK( false == bool( resonances.interpolation() ) );
+      CHECK( 3 == resonances.reactionIDs().size() );
+      CHECK( "n,Cf252->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Cf252->fission" == resonances.reactionIDs()[1].symbol() );
+      CHECK( "n,Cf252->n,Cf252" == resonances.reactionIDs()[2].symbol() );
 
       auto compoundsystem = std::get< legacy::resolved::CompoundSystem< SingleLevelBreitWigner > >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/fromENDFUnresolved.test.hpp
+++ b/src/resonanceReconstruction/rmatrix/test/fromENDFUnresolved.test.hpp
@@ -27,6 +27,9 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( 100000. == Approx( resonances.upperEnergy().value ) );
       CHECK( true == bool( resonances.interpolation() ) );
       CHECK( 2 == resonances.interpolation().value() );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Na22->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Na22->n,Na22" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
@@ -521,6 +524,10 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( 30000. == Approx( resonances.upperEnergy().value ) );
       CHECK( true == bool( resonances.interpolation() ) );
       CHECK( 2 == resonances.interpolation().value() );
+      CHECK( 3 == resonances.reactionIDs().size() );
+      CHECK( "n,Pu239->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Pu239->fission" == resonances.reactionIDs()[1].symbol() );
+      CHECK( "n,Pu239->n,Pu239" == resonances.reactionIDs()[2].symbol() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
@@ -1226,6 +1233,9 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( 10000. == Approx( resonances.upperEnergy().value ) );
       CHECK( true == bool( resonances.interpolation() ) );
       CHECK( 5 == resonances.interpolation().value() );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Er167->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Er167->n,Er167" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 
@@ -1531,6 +1541,9 @@ SCENARIO( "fromENDF - legacy unresolved resonances" ) {
       CHECK( 100000. == Approx( resonances.upperEnergy().value ) );
       CHECK( true == bool( resonances.interpolation() ) );
       CHECK( 2 == resonances.interpolation().value() );
+      CHECK( 2 == resonances.reactionIDs().size() );
+      CHECK( "n,Au197->capture" == resonances.reactionIDs()[0].symbol() );
+      CHECK( "n,Au197->n,Au197" == resonances.reactionIDs()[1].symbol() );
 
       auto compoundsystem = std::get< legacy::unresolved::CompoundSystem >( resonances.compoundSystem() );
 

--- a/src/resonanceReconstruction/rmatrix/test/rmatrix.test.cpp
+++ b/src/resonanceReconstruction/rmatrix/test/rmatrix.test.cpp
@@ -12,7 +12,7 @@ using Spin = rmatrix::Spin;
 using ResonanceRange = endf::ResonanceRange;
 
 constexpr AtomicMass neutronMass = 1.008664 * daltons;
-constexpr ElectricalCharge elementaryCharge = 1.602e-19 * coulomb;
+constexpr ElectricalCharge elementaryCharge = dimwits::constant::elementaryCharge;
 
 #include "resonanceReconstruction/rmatrix/test/possibleChannelTotalAngularMomentumValues.test.hpp"
 #include "resonanceReconstruction/rmatrix/test/possibleChannelSpinValues.test.hpp"


### PR DESCRIPTION
SpinGroup and CompoundSystem of all shapes and sizes (rmatrix, resolved and unresolved) now have a function to retrieve the reaction identifiers defined in them. A visit function on the Reconstructor was added to take advantage of this.